### PR TITLE
Allow GeoJson renderer to handle Carto's encrypted 'the_geom' data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /mnt/datasette
 # for csv import - https://datasette.io/tools/csvs-to-sqlite
 # for datasette db maniupluations and tools - https://datasette.io/tools/sqlite-utils
 # for geojson api responses - https://pypi.org/project/geojson/
-RUN pip install csvs-to-sqlite sqlite-utils geojson
+RUN pip install csvs-to-sqlite sqlite-utils geojson plpygis
 
 # Add the csv data files
 COPY data/ .

--- a/plugins/geo_json_renderer.py
+++ b/plugins/geo_json_renderer.py
@@ -25,7 +25,7 @@ async def render_geo_json(
 
     for row in result:
         # Is this a blatant Point object?
-        if 'longitude' in row and 'latitude' in row:
+        if 'longitude' in row.keys() and 'latitude' in row.keys():
             # https://geojson.org/geojson-spec.html#id2
             point = geojson.Point((row['longitude'], row['latitude']))
             # create a geojson feature
@@ -34,7 +34,7 @@ async def render_geo_json(
             feature_list.append(feature)
         
         # Otherwise, does this have a "the_geom" object, which was used in the old Carto database, which encodes geographical data as a string in the "well-known binary" format?
-        elif 'the_geom' in row:
+        elif 'the_geom' in row.keys():
             feature = Geometry(row['the_geom'])
             feature_list.append(feature)
           

--- a/plugins/geo_json_renderer.py
+++ b/plugins/geo_json_renderer.py
@@ -25,7 +25,7 @@ async def render_geo_json(
 
     for row in result:
         # Is this a blatant Point object?
-        if hasattr(row, 'longitude') and hasattr(row, 'latitude'):
+        if 'longitude' in row and 'latitude' in row:
             # https://geojson.org/geojson-spec.html#id2
             point = geojson.Point((row['longitude'], row['latitude']))
             # create a geojson feature
@@ -34,7 +34,7 @@ async def render_geo_json(
             feature_list.append(feature)
         
         # Otherwise, does this have a "the_geom" object, which was used in the old Carto database, which encodes geographical data as a string in the "well-known binary" format?
-        elif hasattr(row, 'the_geom'):
+        if 'the_geom' in row:
             feature = Geometry(row['the_geom'])
             feature_list.append(feature)
           

--- a/plugins/geo_json_renderer.py
+++ b/plugins/geo_json_renderer.py
@@ -34,7 +34,7 @@ async def render_geo_json(
             feature_list.append(feature)
         
         # Otherwise, does this have a "the_geom" object, which was used in the old Carto database, which encodes geographical data as a string in the "well-known binary" format?
-        if 'the_geom' in row:
+        elif 'the_geom' in row:
             feature = Geometry(row['the_geom'])
             feature_list.append(feature)
           


### PR DESCRIPTION
## PR Overview

Context: for reasons that evade me, the old Carto database sometimes encodes its geographical data into a "the_geom" field. This field contains the GeoJSON feature, but encoded as a string in the [well known binary](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) format.

This PR expands the GeoJSON renderer to read the old "the_geom" field and translate it into a proper JSON-ified object that can be read by some JavaScript.

- Additionally, the renderer has some safety catches - it no longer assumes every row has a lat-long value.

### Status

WIP - I need to figure out how to install the `plpygis` Python library to Docker, since I'm getting `ModuleNotFoundError: No module named 'plpygis'` when running `docker-compose up`.
