### PR TITLE
Add Kenya database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY settings.json ./databases/
 
 # CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "/mnt/datasette/databases"]
 # fix the dbs not starting in immutable mode, https://github.com/simonw/datasette/pull/1229
-CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "2000", "--setting", "hash_urls", "1"]
+CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db", "-i", "databases/kenya.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "2000", "--setting", "hash_urls", "1"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "2000", "--setting", "hash_urls", "1"]
+    command: ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db",  "-i", "databases/kenya.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "2000", "--setting", "hash_urls", "1"]
     ports:
       - "8001:80"
     volumes:


### PR DESCRIPTION
## PR Overview

This PR adds the `kenya` database (for WildWatch Kenya)

The Kenya database...
- consists of 3 tables: aggregations, subjects, cameras
- the aggregations are for survey WF 11374 (production)
- the subjects are from **subject set 77507 only**. We're using a small pool for now to test that the classrooms work.
- the cameras list was provided by the WW Kenya team at San Diego Zoo

In this PR...
- [x] the docker files are updated to ensure Datasette recognises the kenya files
- [x] a `kenya.zip` was added to `/data`
  - ❗ Wait, something's not right here. The `/data/kenya.zip` ain't recognised for git add.
  - @camallen in commit 287802df92b708aa13463911fb51d5428179301e, the .gitignore was updated to specifically "ignore the data file", i.e. `data/**/*` (Wait, how are the gorongosa.zip and darien.zip  still in the repo? Does .gitignore not work retroactively on files that were already added?)
  - Q: is the .gitignore supposed to prevent additional .zip files to be added to the /data folder (e.g. to prevent gargantuan diffs from binary files), or is this some wildcard wonkiness? My default action is to disable .gitignore, git add kenya.zip, commit, then restore .gitignore, but I thought I'd check with you first.

### Status

WIP, waiting on info on the .zip file.