### PR TITLE
Increase "Returned Rows" limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY settings.json ./databases/
 
 # CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "/mnt/datasette/databases"]
 # fix the dbs not starting in immutable mode, https://github.com/simonw/datasette/pull/1229
-CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db", "-i", "databases/kenya.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "2000", "--setting", "hash_urls", "1"]
+CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db", "-i", "databases/kenya.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "50000", "--setting", "hash_urls", "1"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db",  "-i", "databases/kenya.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "2000", "--setting", "hash_urls", "1"]
+    command: ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db",  "-i", "databases/kenya.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "50000", "--setting", "hash_urls", "1"]
     ports:
       - "8001:80"
     volumes:

--- a/settings.json
+++ b/settings.json
@@ -1,4 +1,4 @@
 {
   "sql_time_limit_ms": 60000,
-  "max_returned_rows": 2000
+  "max_returned_rows": 50000
 }


### PR DESCRIPTION
## PR Overview

We've received complaints from WildCam Gorongosa users that their downloaded CSVs are limited to only 2,000 results. We've actually been aware that Datasette has a setting that sets an explicit limit to the number of returned results (2,000 by default, for performance issues) and we were monitoring to see if we'd need to crank up the number - the answer is yes, as it turns out.

The limit has now been cranked up to 50,000, which matches the maximum number of results that might possibly be returned for each project. (Gorongosa's map has 40,388 results with no filters selected; Darien has 38,457; Kenya has 26,382 though that might increase.)

Note: to find out what the "maximum possible results" are, just go to a map page - e.g. https://classroom.zooniverse.org/#/wildcam-darien-lab/explorers/map/ - make sure no filters are selected, and look at the "38457 photo(s)" number. This corresponds to the number of results you SHOULD get when clicking the "Download" (as CSV) button

⚠️ This increase needs to be 1. monitored for performance, and 2. revised when new data goes into the projects. Notably Darien and Kenya.

### Status

WIP. I'm currently running a performance test against my localhost specs to ensure the increased size won't be an issue.