### PR TITLE
bump RAM limits

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -19,10 +19,10 @@ spec:
           image: zooniverse/classroom-maps-api:__IMAGE_TAG__
           resources:
              requests:
-               memory: "250Mi"
+               memory: "1000Mi"
                cpu: "10m"
              limits:
-               memory: "1000Mi"
+               memory: "1500Mi"
                cpu: "1000m"
           ports:
             - containerPort: 80


### PR DESCRIPTION
avoid OOM errors 
```
Image ID:       docker.io/zooniverse/classroom-maps-api@sha256:286f607fbe0b9ac87c9472c3c37bd6edc5b6ce7819647b5378748fec19e95403
    Port:           80/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Wed, 20 Apr 2022 15:29:16 +0100
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Mon, 07 Feb 2022 22:27:22 +0000
      Finished:     Wed, 20 Apr 2022 15:29:15 +0100
    Ready:          True
    Restart Count:  1
```