### PR TITLE
Use latest Datasette

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM datasetteproject/datasette:0.54
+FROM datasetteproject/datasette:latest
 
-RUN apt-get update && apt-get -y upgrade && \
-  apt-get install --no-install-recommends -y \
-  build-essential \
-  unzip \
-  && \
-  apt-get clean
+RUN apt-get update 
+# RUN apt-get -y upgrade
+RUN apt-get install --no-install-recommends -y build-essential unzip
+RUN apt-get clean
 
 WORKDIR /mnt/datasette
 
@@ -14,6 +12,10 @@ WORKDIR /mnt/datasette
 # for datasette db maniupluations and tools - https://datasette.io/tools/sqlite-utils
 # for geojson api responses - https://pypi.org/project/geojson/
 RUN pip install csvs-to-sqlite sqlite-utils geojson plpygis
+
+# pandas 2.0 breaks csvs-to-sqlite.
+# https://github.com/simonw/csvs-to-sqlite/pull/92
+RUN pip install --force-reinstall "pandas~=1.0"
 
 # Add the csv data files
 COPY data/ .
@@ -29,6 +31,8 @@ RUN /usr/local/bin/labs-import-csv-files-to-sqlite.sh
 COPY ./plugins/ ./databases/plugins/
 COPY settings.json ./databases/
 
+RUN datasette install datasette-hashed-urls
+
 # CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "/mnt/datasette/databases"]
 # fix the dbs not starting in immutable mode, https://github.com/simonw/datasette/pull/1229
-CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db", "-i", "databases/kenya.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "50000", "--setting", "hash_urls", "1"]
+CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db", "-i", "databases/kenya.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "50000"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db",  "-i", "databases/kenya.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "50000", "--setting", "hash_urls", "1"]
+    command: ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/darien.db", "-i", "databases/gorongosa.db",  "-i", "databases/kenya.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "50000"]
     ports:
       - "8001:80"
     volumes:


### PR DESCRIPTION
- bump the build to `datasette:latest`.
- remove the deprecated `hash_urls` setting.
- install `datasette-hashed-urls`.
- force `pandas` to 1.0, to avoid a bug in csvs-to-sqlite with v2.0 (https://github.com/simonw/csvs-to-sqlite/issues/88.)
- comment out a broken `apt-get -y upgrade` during the build.

Closes #13.