### PR TITLE
refactor: Replace csvs-to-sqlite with sqlite-utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,9 @@ RUN apt-get clean
 WORKDIR /mnt/datasette
 
 # Datasette tools
-# for csv import - https://datasette.io/tools/csvs-to-sqlite
 # for datasette db maniupluations and tools - https://datasette.io/tools/sqlite-utils
 # for geojson api responses - https://pypi.org/project/geojson/
-RUN pip install csvs-to-sqlite sqlite-utils geojson plpygis
-
-# pandas 2.0 breaks csvs-to-sqlite.
-# https://github.com/simonw/csvs-to-sqlite/pull/92
-RUN pip install --force-reinstall "pandas~=1.0"
+RUN pip install sqlite-utils geojson plpygis
 
 # Add the csv data files
 COPY data/ .

--- a/labs-import-csv-files-to-sqlite.sh
+++ b/labs-import-csv-files-to-sqlite.sh
@@ -14,8 +14,8 @@ do
     table_name="$(basename $input_csv_file .csv)"
     echo ---
     echo "Importing $input_csv_file to table: $table_name in db: $db_name_path"
-    # run the import csv cmd using csvs-to-sqlite
-    csvs-to-sqlite --replace-tables $input_csv_file $db_name_path
+    # run the import csv cmd using sqlite-utils
+    sqlite-utils insert $db_name_path $table_name $input_csv_file --csv --replace --detect-types
     echo
   done
 done


### PR DESCRIPTION
`csvs-to-sqlite` hasn't been updated since 2021, and isn't compatible with the latest version of `pandas`. This PR replaces it with `sqlite-utils`, which is actively maintained.

See https://github.com/zooniverse/subject-set-search-api/pull/62.